### PR TITLE
Block Harvestability Re-work

### DIFF
--- a/src/main/java/com/gtnewhorizons/neid/mixins/Mixins.java
+++ b/src/main/java/com/gtnewhorizons/neid/mixins/Mixins.java
@@ -25,7 +25,8 @@ public enum Mixins {
             "minecraft.MixinS24PacketBlockAction",
             "minecraft.MixinS26PacketMapChunkBulk",
             "minecraft.MixinItemInWorldManager",
-            "minecraft.MixinAnvilChunkLoader"
+            "minecraft.MixinAnvilChunkLoader",
+            "minecraft.MixinBlock"
         ).setApplyIf(() -> true)),
     VANILLA_STARTUP_CLIENT(new Builder("Start Vanilla Client").addTargetedMod(TargetedMod.VANILLA)
         .setSide(Side.CLIENT).setPhase(Phase.EARLY).addMixinClasses(

--- a/src/main/java/com/gtnewhorizons/neid/mixins/early/minecraft/MixinBlock.java
+++ b/src/main/java/com/gtnewhorizons/neid/mixins/early/minecraft/MixinBlock.java
@@ -1,0 +1,89 @@
+package com.gtnewhorizons.neid.mixins.early.minecraft;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import net.minecraft.block.Block;
+import net.minecraft.init.Blocks;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+
+/**
+ * The mixins within here exist to override the way vanilla Minecraft handles harvest levels for blocks. Vanilla by
+ * default creates two arrays, with a length of 16, with the index being the metadata. These arrays get populated with
+ * default values to exist for every possible metadata value, regardless of if a block even has multiple metadata types.
+ * To use this same system with 16-bit metadata values, means taking several GBs of RAM for just that storage on the
+ * blocks. This instead creates a default value(the same defaults as normal vanilla, just not populated for every
+ * metadata value) and then creates a hashmap for lookups which gets populated as needed via setHarvestLevel calls. If a
+ * value is not present for the requested metadata in the map, then the default will be returned instead.
+ */
+@Mixin(Block.class)
+public class MixinBlock {
+
+    private String defaultHarvestTool = null;
+    private int defaultHarvestLevel = -1;
+    private Map<Integer, String> harvestToolMap = new HashMap<Integer, String>();
+    private Map<Integer, Integer> harvestLevelMap = new HashMap<Integer, Integer>();
+
+    @Shadow(remap = false)
+    private String[] harvestTool = null;
+
+    @Shadow(remap = false)
+    private int[] harvestLevel = null;
+
+    /**
+     * @author Cleptomania
+     * @reason Support 16-bit metadata without using GBs of memory
+     */
+    @Overwrite(remap = false)
+    public void setHarvestLevel(String toolClass, int level) {
+        this.defaultHarvestTool = toolClass;
+        this.defaultHarvestLevel = level;
+    }
+
+    /**
+     * @author Cleptomania
+     * @reason Support 16-bit metadata without using GBs of memory
+     */
+    @Overwrite(remap = false)
+    public void setHarvestLevel(String toolClass, int level, int metadata) {
+        this.harvestToolMap.put(metadata, toolClass);
+        this.harvestLevelMap.put(metadata, level);
+    }
+
+    /**
+     * @author Cleptomania
+     * @reason Support 16-bit metadata without using GBs of memory
+     */
+    @Overwrite(remap = false)
+    public String getHarvestTool(int metadata) {
+        return this.harvestToolMap.getOrDefault(metadata, this.defaultHarvestTool);
+    }
+
+    /**
+     * @author Cleptomania
+     * @reason Support 16-bit metadata without using GBs of memory
+     */
+    @Overwrite(remap = false)
+    public int getHarvestLevel(int metadata) {
+        return this.harvestLevelMap.getOrDefault(metadata, this.defaultHarvestLevel);
+    }
+
+    /**
+     * @author Cleptomania
+     * @reason Support 16-bit metadata without using GBs of memory
+     */
+    @Overwrite(remap = false)
+    public boolean isToolEffective(String type, int metadata) {
+        Block self = ((Block) (Object) this);
+        if ("pickaxe".equals(type)
+                && (self == Blocks.redstone_ore || self == Blocks.lit_redstone_ore || self == Blocks.obsidian))
+            return false;
+        String harvestTool = this.getHarvestTool(metadata);
+        if (harvestTool == null) return false;
+        return harvestTool.equals(type);
+    }
+
+}


### PR DESCRIPTION
This overwrites a number of methods added by Forge to the vanilla `Block` class.

Forge creates two arrays on every block, one which is an `int[16]` and one which is a `String[16]`. These are initialized to `-1` and `null` values as a default for every position in the array. The indexes of these arrays correspond to the possible block metadata values. This is, to say the least, horrible for memory usage, and does not scale to the eventual 16-bit metadata increase in NotEnoughIDs.

This replaces the above system with a class level default String and int for the harvest level and effective tool, while simultaneously creating a HashMap to each array. The hashmap by default has no values, and will only get values populated for the metadata it needs them for, done by calling the `setHarvestLevel` method with a metadata. If the metadata value is not present within the hashmap, then the class default is returned.

This maintains the exact same API that was provided by the public functions, while overwriting the internal private functionality, so there is unlikely to be any collision with these internal values. A class dump of the full GTNH pack shows no ASM collisions in this area.

I have tested in full pack with a few things, including GT tools and specifically with various tinker's tool materials against different ores to ensure that this doesn't hurt anything related to those. Everything still works as anticipated it just uses far less memory than before and helps paves the way for 16-bit metadata.