### PR TITLE
Fix for static array in S21PacketChunkData

### DIFF
--- a/src/main/java/com/gtnewhorizons/neid/mixins/early/minecraft/MixinS21PacketChunkData.java
+++ b/src/main/java/com/gtnewhorizons/neid/mixins/early/minecraft/MixinS21PacketChunkData.java
@@ -4,13 +4,10 @@ import net.minecraft.network.play.server.S21PacketChunkData;
 import net.minecraft.world.chunk.storage.ExtendedBlockStorage;
 
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Constant;
-import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyConstant;
 import org.spongepowered.asm.mixin.injection.Redirect;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import com.gtnewhorizons.neid.Constants;
 import com.gtnewhorizons.neid.mixins.interfaces.IExtendedBlockStorageMixin;
@@ -18,19 +15,19 @@ import com.gtnewhorizons.neid.mixins.interfaces.IExtendedBlockStorageMixin;
 @Mixin(S21PacketChunkData.class)
 public class MixinS21PacketChunkData {
 
-    @Shadow
-    private static byte[] field_149286_i;
-
-    @Inject(method = "<init>()V", at = @At(value = "RETURN"), require = 1)
-    private void neid$ConstructorAddition(CallbackInfo CI) {
-        field_149286_i = new byte[Constants.BYTES_PER_CHUNK];
+    @ModifyConstant(
+            method = "<clinit>",
+            constant = @Constant(intValue = Constants.VANILLA_BYTES_PER_CHUNK),
+            require = 1)
+    private static int neid$OverrideBytesPerChunk1(int old) {
+        return Constants.BYTES_PER_CHUNK;
     }
 
     @ModifyConstant(
             method = "func_149275_c()I",
             constant = @Constant(intValue = Constants.VANILLA_BYTES_PER_CHUNK),
             require = 1)
-    private static int neid$readPacketData_Constant1(int i) {
+    private static int neid$OverrideBytesPerChunk2(int i) {
         return Constants.BYTES_PER_CHUNK;
     }
 


### PR DESCRIPTION
Within S21PacketChunkData, there is a static field named `field_149286_i`. Previously, we were shadowing this field, and modifying it by setting it in `@Inject` mixin on the constructor of the class.

This was causing some use cases of this value in a static constant to not have the modified value, and be still running with the normal vanilla value, which would result in a crash which would (wrongly) indicate FastCraft as the likely culprit. This does not happen all the time, and FastCraft does seem to trigger it to happen more often.

This problem was reported in https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14956 and exists in current nightlies starting from 238(Introduced in NEID 1.5.0) until whenever this fix gets released.