### PR TITLE
Fixes for Multiplayer

### DIFF
--- a/src/main/java/com/gtnewhorizons/neid/Constants.java
+++ b/src/main/java/com/gtnewhorizons/neid/Constants.java
@@ -59,13 +59,15 @@ public class Constants {
     /**
      * This number is the total bytes stored in an EBS, minute the lighting data. It is: (LSB + MSB + Metadata) *
      * BLOCKS_PER_EBS(4096) In vanilla: 8 + 4 + 4 = 16 bits per block = 2 bytes per block * 4096 = 8192 Our equation: 16
-     * + 0 + 16 = 20 bits per block = 4 bytes per block * 4096 = 16384.
+     * + 0 + 16 = 32 bits per block = 4 bytes per block * 4096 = 16384. However, even though we're not using MSB, it
+     * still needs to get padded into the byte[] where this calculation is used. So we have to pad in 2048 bits for
+     * that. So our calcuation is actually: 16 + 0.5 + 16 = 32.5 bits per block = 4.5 bytes per block * 4096 = 18432.
      *
      * If you look at vanilla source code, this value will be 2048 because seemingly Vanilla handles less EBS per chunk?
      * Unsure, but Forge ASM's this value to 8192, so that is what we are looking for to modify.
      */
-    public static final int BYTES_PER_EBS_MINUS_LIGHTING = 16384;
-    public static final int VANILLA_BYTES_PER_EBS_MINUS_LIGHTING = 8192;
+    public static final int BYTES_PER_EBS_MINUS_LIGHTING_BUT_INCLUDE_MSB = 18432;
+    public static final int VANILLA_BYTES_PER_EBS_MINUS_LIGHTING_BUT_INCLUDE_MSB = 8192;
 
     public static final int MAX_DATA_WATCHER_ID = 127;
 }

--- a/src/main/java/com/gtnewhorizons/neid/mixins/early/minecraft/MixinExtendedBlockStorage.java
+++ b/src/main/java/com/gtnewhorizons/neid/mixins/early/minecraft/MixinExtendedBlockStorage.java
@@ -5,7 +5,6 @@ import java.nio.ShortBuffer;
 
 import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
-import net.minecraft.world.chunk.NibbleArray;
 import net.minecraft.world.chunk.storage.ExtendedBlockStorage;
 
 import org.spongepowered.asm.mixin.Mixin;
@@ -51,11 +50,6 @@ public class MixinExtendedBlockStorage implements IExtendedBlockStorageMixin {
         final byte[] ret = new byte[this.block16BMetaArray.length * 2];
         ByteBuffer.wrap(ret).asShortBuffer().put(this.block16BMetaArray);
         return ret;
-    }
-
-    @Override
-    public NibbleArray getBlockMetaNibble() {
-        return new NibbleArray(this.getBlockMeta(), 4);
     }
 
     @Override

--- a/src/main/java/com/gtnewhorizons/neid/mixins/early/minecraft/MixinS26PacketMapChunkBulk.java
+++ b/src/main/java/com/gtnewhorizons/neid/mixins/early/minecraft/MixinS26PacketMapChunkBulk.java
@@ -13,9 +13,9 @@ public class MixinS26PacketMapChunkBulk {
 
     @ModifyConstant(
             method = "readPacketData",
-            constant = @Constant(intValue = Constants.VANILLA_BYTES_PER_EBS_MINUS_LIGHTING),
+            constant = @Constant(intValue = Constants.VANILLA_BYTES_PER_EBS_MINUS_LIGHTING_BUT_INCLUDE_MSB),
             require = 1)
     private static int neid$readPacketConstantUpdate(int i) {
-        return Constants.BYTES_PER_EBS_MINUS_LIGHTING;
+        return Constants.BYTES_PER_EBS_MINUS_LIGHTING_BUT_INCLUDE_MSB;
     }
 }

--- a/src/main/java/com/gtnewhorizons/neid/mixins/interfaces/IExtendedBlockStorageMixin.java
+++ b/src/main/java/com/gtnewhorizons/neid/mixins/interfaces/IExtendedBlockStorageMixin.java
@@ -1,7 +1,5 @@
 package com.gtnewhorizons.neid.mixins.interfaces;
 
-import net.minecraft.world.chunk.NibbleArray;
-
 public interface IExtendedBlockStorageMixin {
 
     short[] getBlock16BArray();
@@ -11,8 +9,6 @@ public interface IExtendedBlockStorageMixin {
     byte[] getBlockData();
 
     byte[] getBlockMeta();
-
-    NibbleArray getBlockMetaNibble();
 
     void setBlockData(byte[] data, int offset);
 


### PR DESCRIPTION
This PR contains 2 fixes which are related to the same thing.

There was a bug which only occurred when running with a dedicated server and a client, but not in singleplayer. This is because the packets do not get serialized/deserialized in singleplayer despite the game running an internal server. The packets are created and shared directly to the client side code.

This fixes some of the packet building in `S21PacketChunkData` to properly copy the data it needs from `ExtendedBlockStorage`, it also slightly updates the `Chunk.fillChunk` mixins to be more in line with what we're doing here, which ultimately requires less needless allocations and removes one unnecessary mixin.

The second fix is related to `S26PacketMapChunkBulk`. The mixin we have for this is intended to increase the total number of bytes for the `byte[]` in this packet. To understand this fix, you need to know that in Vanilla, block IDs are composed of an LSB and an MSB value, the LSB value being 8 bits, and the MSB value being 4 bits. This MSB value generally shares the same underlying `byte[]` as the 4 bits for metadata, so prior to us extending the metadata to 16-bits, this calculation still had half of a byte accounted for the MSB value.

While we don't actually use the MSB value, it still needs to be accounted for in the byte arrays or certain things will panic and crash, when we extended the metadata, since metadata was no longer sharing a `byte[]` with MSB data, the half a byte for MSB was mistakenly removed from this calculation, so the change to `S26PacketMapChunkBulk` simply pads that half a byte back into the total length for the `byte[]`.