### PR TITLE
Change fake NibbleArray to not use empty byte array for Thermos compat

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,5 +1,5 @@
 // Add your dependencies here
 
 dependencies {
-    api("com.github.GTNewHorizons:GTNHLib:0.2.3:dev")
+    api("com.github.GTNewHorizons:GTNHLib:0.2.4:dev")
 }

--- a/src/main/java/com/gtnewhorizons/neid/mixins/early/minecraft/MixinS21PacketChunkData.java
+++ b/src/main/java/com/gtnewhorizons/neid/mixins/early/minecraft/MixinS21PacketChunkData.java
@@ -20,7 +20,7 @@ import com.llamalad7.mixinextras.sugar.ref.LocalIntRef;
 public class MixinS21PacketChunkData {
 
     private static final byte[] fakeByteArray = new byte[0];
-    private static final NibbleArray fakeNibbleArray = new NibbleArray(fakeByteArray, 0);
+    private static final NibbleArray fakeNibbleArray = new NibbleArray(0, 0);
 
     @ModifyConstant(
             method = "<clinit>",

--- a/src/main/java/com/gtnewhorizons/neid/mixins/early/minecraft/client/MixinChunk.java
+++ b/src/main/java/com/gtnewhorizons/neid/mixins/early/minecraft/client/MixinChunk.java
@@ -24,7 +24,7 @@ import com.llamalad7.mixinextras.sugar.ref.LocalIntRef;
 public class MixinChunk {
 
     private static final byte[] fakeByteArray = new byte[0];
-    private static final NibbleArray fakeNibbleArray = new NibbleArray(fakeByteArray, 0);
+    private static final NibbleArray fakeNibbleArray = new NibbleArray(0, 0);
 
     @Shadow
     private ExtendedBlockStorage[] storageArrays;


### PR DESCRIPTION
This should fix a crash with Thermos where it is incompatible with receiving a completely empty(but not null) byte array for the underlying data array of a `NibbleArray`. This is only used in NEID to trick minecraft into thinking the length of the `NibbleArray` is zero, initializing in this way accomplishes the same but shouldn't break Thermos.

The `MixinChunk` change wouldn't actually need to change, but figured I'd keep the approaches in sync since they do more or less the exact same thing as `MixinS21PacketChunkData` which is the one that actually breaks Thermos.