### PR TITLE
Fix for Client Side Biome ID when server is run with Thermos

### DIFF
--- a/src/main/java/com/gtnewhorizons/neid/Common.java
+++ b/src/main/java/com/gtnewhorizons/neid/Common.java
@@ -1,0 +1,15 @@
+package com.gtnewhorizons.neid;
+
+public class Common {
+
+    public static boolean thermosTainted;
+
+    static {
+        try {
+            Class.forName("org.bukkit.World");
+            Common.thermosTainted = true;
+        } catch (ClassNotFoundException e) {
+            Common.thermosTainted = false;
+        }
+    }
+}

--- a/src/main/java/com/gtnewhorizons/neid/mixins/Mixins.java
+++ b/src/main/java/com/gtnewhorizons/neid/mixins/Mixins.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Supplier;
 
+import com.gtnewhorizons.neid.Common;
 import com.gtnewhorizons.neid.NEIDConfig;
 
 import cpw.mods.fml.relauncher.FMLLaunchHandler;
@@ -20,7 +21,6 @@ public enum Mixins {
             "minecraft.MixinExtendedBlockStorage",
             "minecraft.MixinStatList",
             "minecraft.MixinBlockFire",
-            "minecraft.MixinS21PacketChunkData",
             "minecraft.MixinS22PacketMultiBlockChange",
             "minecraft.MixinS24PacketBlockAction",
             "minecraft.MixinS26PacketMapChunkBulk",
@@ -28,6 +28,12 @@ public enum Mixins {
             "minecraft.MixinAnvilChunkLoader",
             "minecraft.MixinBlock"
         ).setApplyIf(() -> true)),
+    VANILLA_STARTUP_ONLY_WITHOUT_THERMOS(new Builder("Start Vanilla No Thermos").addTargetedMod(TargetedMod.VANILLA).setSide(Side.BOTH).setPhase(Phase.EARLY).addMixinClasses(
+        "minecraft.MixinS21PacketChunkData"
+    ).setApplyIf(() -> !Common.thermosTainted)),
+    VANILLA_STARTUP_ONLY_WITH_THERMOS(new Builder("Start Vanilla with Thermos").addTargetedMod(TargetedMod.VANILLA).setSide(Side.BOTH).setPhase(Phase.EARLY).addMixinClasses(
+        "minecraft.MixinS21PacketChunkDataThermosTainted"
+    ).setApplyIf(() -> Common.thermosTainted)),
     VANILLA_STARTUP_CLIENT(new Builder("Start Vanilla Client").addTargetedMod(TargetedMod.VANILLA)
         .setSide(Side.CLIENT).setPhase(Phase.EARLY).addMixinClasses(
             "minecraft.client.MixinRenderGlobal",

--- a/src/main/java/com/gtnewhorizons/neid/mixins/early/minecraft/MixinS21PacketChunkDataThermosTainted.java
+++ b/src/main/java/com/gtnewhorizons/neid/mixins/early/minecraft/MixinS21PacketChunkDataThermosTainted.java
@@ -1,0 +1,113 @@
+package com.gtnewhorizons.neid.mixins.early.minecraft;
+
+import net.minecraft.network.play.server.S21PacketChunkData;
+import net.minecraft.world.chunk.NibbleArray;
+import net.minecraft.world.chunk.storage.ExtendedBlockStorage;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import com.gtnewhorizons.neid.Constants;
+import com.gtnewhorizons.neid.mixins.interfaces.IExtendedBlockStorageMixin;
+import com.llamalad7.mixinextras.injector.WrapWithCondition;
+import com.llamalad7.mixinextras.sugar.Local;
+import com.llamalad7.mixinextras.sugar.ref.LocalIntRef;
+
+@Mixin(S21PacketChunkData.class)
+public class MixinS21PacketChunkDataThermosTainted {
+
+    private static final byte[] fakeByteArray = new byte[0];
+    private static final NibbleArray fakeNibbleArray = new NibbleArray(0, 0);
+
+    @ModifyConstant(
+            method = "<clinit>",
+            constant = @Constant(intValue = Constants.VANILLA_BYTES_PER_CHUNK),
+            require = 1)
+    private static int neid$OverrideBytesPerChunk1(int old) {
+        return Constants.BYTES_PER_CHUNK;
+    }
+
+    @ModifyConstant(
+            method = "func_149275_c()I",
+            constant = @Constant(intValue = Constants.VANILLA_BYTES_PER_CHUNK),
+            require = 1)
+    private static int neid$OverrideBytesPerChunk2(int i) {
+        return Constants.BYTES_PER_CHUNK;
+    }
+
+    @ModifyConstant(
+            method = "readPacketData",
+            constant = @Constant(intValue = Constants.VANILLA_BYTES_PER_EBS),
+            require = 1)
+    private static int neid$OverrideBytesPerEBS(int i) {
+        return Constants.BYTES_PER_EBS;
+    }
+
+    @Redirect(
+            method = "func_149269_a",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/world/chunk/storage/ExtendedBlockStorage;getBlockLSBArray()[B"),
+            require = 1)
+    private static byte[] neid$injectNewDataCopy(ExtendedBlockStorage ebs, @Local(ordinal = 0) byte[] thebytes,
+            @Local(ordinal = 1) LocalIntRef offset) {
+        IExtendedBlockStorageMixin ebsMixin = (IExtendedBlockStorageMixin) ebs;
+        byte[] data = ebsMixin.getBlockData();
+        System.arraycopy(data, 0, thebytes, offset.get(), Constants.BLOCKS_PER_EBS * 2);
+        offset.set(offset.get() + (Constants.BLOCKS_PER_EBS * 2));
+        return fakeByteArray;
+    }
+
+    @WrapWithCondition(
+            method = "func_149269_a",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Ljava/lang/System;arraycopy(Ljava/lang/Object;ILjava/lang/Object;II)V",
+                    ordinal = 0),
+            require = 1)
+    private static boolean neid$cancelLSBArrayCopy(Object a, int i, Object b, int j, int k) {
+        return false;
+    }
+
+    @Redirect(
+            method = "func_149269_a",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/world/chunk/storage/ExtendedBlockStorage;getMetadataArray()Lnet/minecraft/world/chunk/NibbleArray;"),
+            require = 1)
+    private static NibbleArray neid$injectNewMetadataCopy(ExtendedBlockStorage ebs, @Local(ordinal = 0) byte[] thebytes,
+            @Local(ordinal = 1) LocalIntRef offset) {
+        IExtendedBlockStorageMixin ebsMixin = (IExtendedBlockStorageMixin) ebs;
+        byte[] meta = ebsMixin.getBlockMeta();
+        System.arraycopy(meta, 0, thebytes, offset.get(), Constants.BLOCKS_PER_EBS * 2);
+        offset.set(offset.get() + (Constants.BLOCKS_PER_EBS * 2));
+        return fakeNibbleArray;
+    }
+
+    @WrapWithCondition(
+            method = "func_149269_a",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/world/chunk/NibbleArray;copyToByteArray([BI)I",
+                    ordinal = 0,
+                    remap = false),
+            require = 1)
+    private static boolean neid$cancelMetadataArrayCopy(NibbleArray nibbleArray, byte[] bytes, int i) {
+        return false;
+    }
+
+    @Redirect(
+            method = "func_149269_a",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/world/chunk/storage/ExtendedBlockStorage;getBlockMSBArray()Lnet/minecraft/world/chunk/NibbleArray;",
+                    ordinal = 0),
+            require = 1)
+    private static NibbleArray neid$nukeMSBLoop(ExtendedBlockStorage ebs) {
+        return null;
+    }
+
+}


### PR DESCRIPTION
Fixes a bug where when the server is run with Thermos, the client would register every biome as an ocean biome, causing incorrect reporting of the biome, but also for example incorrect rendering of grass colors.

This was caused by https://github.com/GTNewHorizons/Thermos/blob/1.7.10/patches/net/minecraft/network/play/server/S21PacketChunkData.java.patch#L16-L21 this patch in thermos which causes a mixin that targets the old `System.arraycopy` to fail to apply, so the fix applies the same logic but to the `copyToByteArray` method which replaces it.