### PR TITLE
Handle block change packets properly for metadata

### DIFF
--- a/src/main/java/com/gtnewhorizons/neid/mixins/Mixins.java
+++ b/src/main/java/com/gtnewhorizons/neid/mixins/Mixins.java
@@ -22,6 +22,7 @@ public enum Mixins {
             "minecraft.MixinStatList",
             "minecraft.MixinBlockFire",
             "minecraft.MixinS22PacketMultiBlockChange",
+            "minecraft.MixinS23PacketBlockChange",
             "minecraft.MixinS24PacketBlockAction",
             "minecraft.MixinS26PacketMapChunkBulk",
             "minecraft.MixinItemInWorldManager",

--- a/src/main/java/com/gtnewhorizons/neid/mixins/early/minecraft/MixinS23PacketBlockChange.java
+++ b/src/main/java/com/gtnewhorizons/neid/mixins/early/minecraft/MixinS23PacketBlockChange.java
@@ -1,0 +1,34 @@
+package com.gtnewhorizons.neid.mixins.early.minecraft;
+
+import net.minecraft.network.PacketBuffer;
+import net.minecraft.network.play.server.S23PacketBlockChange;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import io.netty.buffer.ByteBuf;
+
+@Mixin(S23PacketBlockChange.class)
+public class MixinS23PacketBlockChange {
+
+    @Redirect(
+            method = "readPacketData",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/network/PacketBuffer;readUnsignedByte()S", ordinal = 1),
+            require = 1)
+    private short neid$redirectMetadataRead(PacketBuffer data) {
+        return data.readShort();
+    }
+
+    @Redirect(
+            method = "writePacketData",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/network/PacketBuffer;writeByte(I)Lio/netty/buffer/ByteBuf;",
+                    ordinal = 1),
+            require = 1)
+    private ByteBuf neid$redirectMetadataWrite(PacketBuffer data, int i) {
+        return data.writeShort(i);
+    }
+
+}


### PR DESCRIPTION
Adds a mixin for S23PacketBlockChange, previously this packet was writing the metadata as an unsigned byte causing any metadata values to be truncated to 255 when sent from server to client when playing on a dedicated server and going through packet serialization.

This redirects the unsigned byte read/write to use a short