### PR TITLE
Thermos Compat with postNeidWorldsSupport

### DIFF
--- a/src/main/java/com/gtnewhorizons/neid/mixins/early/minecraft/MixinAnvilChunkLoader.java
+++ b/src/main/java/com/gtnewhorizons/neid/mixins/early/minecraft/MixinAnvilChunkLoader.java
@@ -1,7 +1,5 @@
 package com.gtnewhorizons.neid.mixins.early.minecraft;
 
-import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
-import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.chunk.NibbleArray;
 import net.minecraft.world.chunk.storage.AnvilChunkLoader;
@@ -14,6 +12,8 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 import com.gtnewhorizons.neid.Constants;
 import com.gtnewhorizons.neid.NEIDConfig;
 import com.gtnewhorizons.neid.mixins.interfaces.IExtendedBlockStorageMixin;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
 
 @Mixin(AnvilChunkLoader.class)
@@ -139,28 +139,22 @@ public class MixinAnvilChunkLoader {
     }
 
     @Redirect(
-        method = "readChunkFromNBT",
-        at = @At(
-            value = "INVOKE",
-            target = "Lnet/minecraft/nbt/NBTTagCompound;getByteArray(Ljava/lang/String;)[B",
-            ordinal = 2
-        ),
-        require = 1
-    )
+            method = "readChunkFromNBT",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/nbt/NBTTagCompound;getByteArray(Ljava/lang/String;)[B",
+                    ordinal = 2),
+            require = 1)
     private byte[] neid$cancelByteArrayCreationForMetadata(NBTTagCompound nbttagcompound1, String s) {
         return fakeByteArray;
     }
 
     @WrapOperation(
-        method = "readChunkFromNBT",
-        at = @At(
-            value = "NEW",
-            target = "Lnet/minecraft/world/chunk/NibbleArray;",
-            ordinal = 1
-        ),
-        require = 1
-    )
-    private NibbleArray neid$cancelNibbleArrayCreationForMetadata(byte[] bytes, int i, Operation<NibbleArray> original) {
+            method = "readChunkFromNBT",
+            at = @At(value = "NEW", target = "Lnet/minecraft/world/chunk/NibbleArray;", ordinal = 1),
+            require = 1)
+    private NibbleArray neid$cancelNibbleArrayCreationForMetadata(byte[] bytes, int i,
+            Operation<NibbleArray> original) {
         return fakeNibbleArray;
     }
 

--- a/src/main/java/com/gtnewhorizons/neid/mixins/early/minecraft/MixinAnvilChunkLoader.java
+++ b/src/main/java/com/gtnewhorizons/neid/mixins/early/minecraft/MixinAnvilChunkLoader.java
@@ -17,6 +17,8 @@ import com.llamalad7.mixinextras.sugar.Local;
 @Mixin(AnvilChunkLoader.class)
 public class MixinAnvilChunkLoader {
 
+    private static byte[] fakeByteArray = new byte[]{1};
+
     @Redirect(
             method = "writeChunkToNBT",
             at = @At(
@@ -131,6 +133,26 @@ public class MixinAnvilChunkLoader {
             require = 1)
     private boolean neid$overrideReadMSBArray(NBTTagCompound nbttagcompound1, String s, int i) {
         return false;
+    }
+
+    @Redirect(
+        method = "readChunkFromNBT",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/nbt/NBTTagCompound;getByteArray(Ljava/lang/String;)[B",
+            ordinal = 2
+        ),
+        require = 1
+    )
+    private byte[] neid$injectFakeByteArrayForThermos(NBTTagCompound nbttagcompound1, String s) {
+        /*
+        This is here because Thermos(Spigot) makes some changes to NibbleArray which cause creating a
+        NibbleArray with an empty byte[] to crash. When the postNeidWorldsSupport option is enabled, it means
+        that the vanilla byte[] in the NBT is no longer stored there. Which causes the NibbleArray creation
+        for it to be done with an empty byte[]. This just returns a static fake byte[] with one value in it,
+        because we're not actually going to use this NibbleArray anymore, but it still needs to be created.
+         */
+        return fakeByteArray;
     }
 
     @Redirect(


### PR DESCRIPTION
When postNeidWorldsSupport is disabled, that means the vanilla `Blocks` and `Data` byte[] values no longer get stored in the NBT. This means that during `readChunkFromNBT`, the NibbleArray created for the block metadata, gets created with an empty byte[].

Thermos(specifically spigot), [makes this change](https://github.com/GTNewHorizons/Thermos/blob/ab8a329b10f0857cb246e5d791ede8e1f7419c63/patches/net/minecraft/world/chunk/NibbleArray.java.patch#L40-L59) to NibbleArray, which causes it to crash when created with an empty byte[]. So this change injects a static fake byte[] with one value in it that will be passed into the NibbleArray creation, instead of trying to pull the value from the `Data` NBT tag.