### PR TITLE
Client block transformer

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ modId = neid
 modGroup = com.gtnewhorizons.neid
 
 # Whether to use modGroup as the maven publishing group.
-# Due to a history of using JitPack, the default is com.github.GTNewHorizons for all mods.
+# When false, com.github.GTNewHorizons is used.
 useModGroupForPublishing = false
 
 # Updates your build.gradle and settings.gradle automatically whenever an update is available.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.27'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.38'
 }
 
 

--- a/src/main/java/com/gtnewhorizons/neid/ClientBlockTransformerRegistry.java
+++ b/src/main/java/com/gtnewhorizons/neid/ClientBlockTransformerRegistry.java
@@ -1,0 +1,40 @@
+package com.gtnewhorizons.neid;
+
+import java.nio.ShortBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.IntToLongFunction;
+
+import net.minecraft.world.World;
+
+import com.gtnewhorizon.gtnhlib.util.data.BlockMeta;
+import com.gtnewhorizons.neid.mixins.interfaces.ClientBlockTransformer;
+
+public class ClientBlockTransformerRegistry {
+
+    private static final List<ClientBlockTransformer> TRANSFORMERS = new ArrayList<>();
+
+    public static void registerTransformer(ClientBlockTransformer transformer) {
+        TRANSFORMERS.add(transformer);
+    }
+
+    public static boolean transformBlock(World world, int x, int y, int z, BlockMeta blockMeta) {
+        int size = TRANSFORMERS.size();
+
+        boolean didSomething = false;
+
+        for (int i = 0; i < size; i++) {
+            didSomething |= TRANSFORMERS.get(i).transformBlock(world, x, y, z, blockMeta);
+        }
+
+        return didSomething;
+    }
+
+    public static void transformBulk(World world, IntToLongFunction coord, ShortBuffer blocks, ShortBuffer metas) {
+        int size = TRANSFORMERS.size();
+
+        for (int i = 0; i < size; i++) {
+            TRANSFORMERS.get(i).transformBulk(world, coord, blocks, metas);
+        }
+    }
+}

--- a/src/main/java/com/gtnewhorizons/neid/mixins/early/minecraft/MixinS21PacketChunkData.java
+++ b/src/main/java/com/gtnewhorizons/neid/mixins/early/minecraft/MixinS21PacketChunkData.java
@@ -149,12 +149,14 @@ public class MixinS21PacketChunkData {
 
         for (int i = 0; i < ebs.length; i++) {
             if (ebs[i] != null && (!firstSync || !ebs[i].isEmpty()) && (flags & 1 << i) != 0) {
+                int ebsY = ebs[i].getYLocation();
+
                 IntToLongFunction coord = blockIndex -> {
                     int x = blockIndex & 15;
                     int z = (blockIndex >> 4) & 15;
                     int y = (blockIndex >> 8) & 255;
 
-                    return CoordinatePacker.pack(x + cx, y, z + cz);
+                    return CoordinatePacker.pack(x + cx, y + ebsY, z + cz);
                 };
 
                 ClientBlockTransformerRegistry.transformBulk(chunk.worldObj, coord, blocks[i], metas[i]);

--- a/src/main/java/com/gtnewhorizons/neid/mixins/early/minecraft/MixinS21PacketChunkData.java
+++ b/src/main/java/com/gtnewhorizons/neid/mixins/early/minecraft/MixinS21PacketChunkData.java
@@ -1,15 +1,24 @@
 package com.gtnewhorizons.neid.mixins.early.minecraft;
 
+import java.nio.ByteBuffer;
+import java.nio.ShortBuffer;
+import java.util.function.IntToLongFunction;
+
 import net.minecraft.network.play.server.S21PacketChunkData;
+import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.NibbleArray;
 import net.minecraft.world.chunk.storage.ExtendedBlockStorage;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyConstant;
 import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import com.gtnewhorizon.gtnhlib.util.CoordinatePacker;
+import com.gtnewhorizons.neid.ClientBlockTransformerRegistry;
 import com.gtnewhorizons.neid.Constants;
 import com.gtnewhorizons.neid.mixins.interfaces.IExtendedBlockStorageMixin;
 import com.llamalad7.mixinextras.injector.WrapWithCondition;
@@ -109,4 +118,47 @@ public class MixinS21PacketChunkData {
         return null;
     }
 
+    @Inject(method = "func_149269_a", at = @At("TAIL"))
+    private static void neid$modifyChunkData(Chunk chunk, boolean firstSync, int flags,
+            CallbackInfoReturnable<S21PacketChunkData.Extracted> cir, @Local S21PacketChunkData.Extracted data) {
+        ExtendedBlockStorage[] ebs = chunk.getBlockStorageArray();
+
+        ShortBuffer[] blocks = new ShortBuffer[ebs.length];
+        ShortBuffer[] metas = new ShortBuffer[ebs.length];
+
+        int cursor = 0;
+
+        final int ebsLength = Constants.BLOCKS_PER_EBS * 2;
+
+        for (int i = 0; i < ebs.length; ++i) {
+            if (ebs[i] != null && (!firstSync || !ebs[i].isEmpty()) && (flags & 1 << i) != 0) {
+                blocks[i] = ByteBuffer.wrap(data.field_150282_a, cursor, ebsLength).asShortBuffer();
+                cursor += ebsLength;
+            }
+        }
+
+        for (int i = 0; i < ebs.length; ++i) {
+            if (ebs[i] != null && (!firstSync || !ebs[i].isEmpty()) && (flags & 1 << i) != 0) {
+                metas[i] = ByteBuffer.wrap(data.field_150282_a, cursor, ebsLength).asShortBuffer();
+                cursor += ebsLength;
+            }
+        }
+
+        int cx = chunk.xPosition * 16;
+        int cz = chunk.zPosition * 16;
+
+        for (int i = 0; i < ebs.length; i++) {
+            if (ebs[i] != null && (!firstSync || !ebs[i].isEmpty()) && (flags & 1 << i) != 0) {
+                IntToLongFunction coord = blockIndex -> {
+                    int x = blockIndex & 15;
+                    int z = (blockIndex >> 4) & 15;
+                    int y = (blockIndex >> 8) & 255;
+
+                    return CoordinatePacker.pack(x + cx, y, z + cz);
+                };
+
+                ClientBlockTransformerRegistry.transformBulk(chunk.worldObj, coord, blocks[i], metas[i]);
+            }
+        }
+    }
 }

--- a/src/main/java/com/gtnewhorizons/neid/mixins/early/minecraft/MixinS22PacketMultiBlockChange.java
+++ b/src/main/java/com/gtnewhorizons/neid/mixins/early/minecraft/MixinS22PacketMultiBlockChange.java
@@ -4,19 +4,26 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 
 import net.minecraft.block.Block;
+import net.minecraft.init.Blocks;
 import net.minecraft.network.play.server.S22PacketMultiBlockChange;
 import net.minecraft.world.chunk.Chunk;
 
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Constant;
 import org.spongepowered.asm.mixin.injection.ModifyConstant;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
+import com.gtnewhorizon.gtnhlib.util.data.BlockMeta;
+import com.gtnewhorizons.neid.ClientBlockTransformerRegistry;
 import com.llamalad7.mixinextras.sugar.Local;
 
 @Mixin(S22PacketMultiBlockChange.class)
 public class MixinS22PacketMultiBlockChange {
+
+    @Unique
+    private final BlockMeta pooled = new BlockMeta(Blocks.air, 0);
 
     /**
      * These values are the number of bytes per block. These are not necessarily the same as within the other
@@ -41,7 +48,25 @@ public class MixinS22PacketMultiBlockChange {
     private void neid$writeShortRedirectInConstructor(DataOutputStream dataOutputStream, int i,
             @Local Chunk p_i45181_3_, @Local(ordinal = 3) int l, @Local(ordinal = 4) int i1, @Local(ordinal = 5) int j1)
             throws IOException {
-        dataOutputStream.writeShort(Block.getIdFromBlock(p_i45181_3_.getBlock(l, j1, i1)));
-        dataOutputStream.writeShort(p_i45181_3_.getBlockMetadata(l, j1, i1));
+        Block block = p_i45181_3_.getBlock(l, j1, i1);
+        int meta = p_i45181_3_.getBlockMetadata(l, j1, i1);
+
+        pooled.setBlock(block);
+        pooled.setBlockMeta(meta);
+
+        boolean didSomething = ClientBlockTransformerRegistry.transformBlock(
+                p_i45181_3_.worldObj,
+                l + p_i45181_3_.xPosition * 16,
+                j1,
+                i1 + p_i45181_3_.zPosition * 16,
+                pooled);
+
+        if (didSomething) {
+            block = pooled.getBlock();
+            meta = pooled.getBlockMeta();
+        }
+
+        dataOutputStream.writeShort(Block.getIdFromBlock(block));
+        dataOutputStream.writeShort(meta);
     }
 }

--- a/src/main/java/com/gtnewhorizons/neid/mixins/early/minecraft/MixinS23PacketBlockChange.java
+++ b/src/main/java/com/gtnewhorizons/neid/mixins/early/minecraft/MixinS23PacketBlockChange.java
@@ -1,16 +1,39 @@
 package com.gtnewhorizons.neid.mixins.early.minecraft;
 
+import net.minecraft.block.Block;
 import net.minecraft.network.PacketBuffer;
 import net.minecraft.network.play.server.S23PacketBlockChange;
+import net.minecraft.world.World;
 
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.gtnewhorizon.gtnhlib.util.data.BlockMeta;
+import com.gtnewhorizons.neid.ClientBlockTransformerRegistry;
 
 import io.netty.buffer.ByteBuf;
 
 @Mixin(S23PacketBlockChange.class)
 public class MixinS23PacketBlockChange {
+
+    @Shadow
+    public Block field_148883_d;
+    @Shadow
+    public int field_148884_e;
+
+    @Inject(method = "<init>(IIILnet/minecraft/world/World;)V", at = @At("TAIL"))
+    public void neid$transformBlock(int x, int y, int z, World world, CallbackInfo ci) {
+        BlockMeta bm = new BlockMeta(field_148883_d, field_148884_e);
+
+        if (ClientBlockTransformerRegistry.transformBlock(world, x, y, z, bm)) {
+            field_148883_d = bm.getBlock();
+            field_148884_e = bm.getBlockMeta();
+        }
+    }
 
     @Redirect(
             method = "readPacketData",

--- a/src/main/java/com/gtnewhorizons/neid/mixins/interfaces/ClientBlockTransformer.java
+++ b/src/main/java/com/gtnewhorizons/neid/mixins/interfaces/ClientBlockTransformer.java
@@ -1,0 +1,95 @@
+package com.gtnewhorizons.neid.mixins.interfaces;
+
+import java.nio.ShortBuffer;
+import java.util.function.IntToLongFunction;
+
+import net.minecraft.block.Block;
+import net.minecraft.init.Blocks;
+import net.minecraft.world.World;
+
+import com.gtnewhorizon.gtnhlib.util.CoordinatePacker;
+import com.gtnewhorizon.gtnhlib.util.data.BlockMeta;
+
+/**
+ * An object that can transform a block before it is sent to the client. This is useful for situations where the client
+ * must see a non-TE block without mutating the server's world (i.e. in rendering where the client should do something
+ * special with a block).
+ */
+public interface ClientBlockTransformer {
+
+    /**
+     * Transforms a single block.
+     * 
+     * @param world     The world
+     * @param x         The world-space x coord
+     * @param y         The world-space y coord
+     * @param z         The world-space z coord
+     * @param blockMeta The existing block/meta. Mutate this object to change the resulting block.
+     * @return True to change the block, false to do nothing
+     */
+    boolean transformBlock(World world, int x, int y, int z, BlockMeta blockMeta);
+
+    /**
+     * Transforms a buffer of block ids + metas. The block and meta buffers are guaranteed to be the same length.
+     * 
+     * @param world  The world
+     * @param coord  A function which takes an index into the buffer and transforms it into a packed x,y,z coordinate.
+     * @param blocks The buffer of block ids.
+     * @param metas  The buffer of meta values.
+     */
+    default void transformBulk(World world, IntToLongFunction coord, ShortBuffer blocks, ShortBuffer metas) {
+        BlockIdCache input = new BlockIdCache();
+        BlockIdCache output = new BlockIdCache();
+
+        int len = blocks.capacity();
+
+        BlockMeta pooled = new BlockMeta(Blocks.air, 0);
+
+        for (int i = 0; i < len; i++) {
+            pooled.setBlock(input.getBlock(blocks.get(i)));
+            pooled.setBlockMeta(metas.get(i));
+
+            long c = coord.applyAsLong(i);
+
+            boolean didSomething = transformBlock(
+                    world,
+                    CoordinatePacker.unpackX(c),
+                    CoordinatePacker.unpackY(c),
+                    CoordinatePacker.unpackZ(c),
+                    pooled);
+
+            if (didSomething) {
+                blocks.put(i, (short) output.getId(pooled.getBlock()));
+                metas.put(i, (short) pooled.getBlockMeta());
+            }
+        }
+    }
+
+    class BlockIdCache {
+
+        public Block block;
+        public int blockId = -1;
+
+        public int getId(Block block) {
+            if (this.block == block) {
+                return blockId;
+            }
+
+            this.block = block;
+            this.blockId = Block.getIdFromBlock(block);
+
+            return blockId;
+        }
+
+        public Block getBlock(int id) {
+            if (id == blockId) {
+                return block;
+            }
+
+            this.blockId = id;
+            this.block = Block.getBlockById(id);
+
+            return block;
+        }
+    }
+}


### PR DESCRIPTION
This adds a mechanism for modifying the blocks sent to the client. This is needed for situations where you want to show one block/meta to the player, while storing another on the server. While this doesn't entirely belong in NEID, it is tightly coupled to NEID's internals and it has several mixin conflicts with the NEID packet mixins. It isn't viable to move this to another mod.

Code changes:
- Add the interface and registry (the registry is undocumented, but the interface should be 100% documented)
- Intercept packet S23, which is sent when the player right clicks a block
- Intercept packet S22, which is sent when 2-64 blocks change in a chunk
- Intercept packets S21 and S26 (via the chunk data extractor method), which are sent when chunks significantly change or are loaded

Testing done:
- Make a transformer that converts all sand to red sand
- Make a transformer that converts sand to red sand when `(x + y + z) % 2 == 0`
- Create a new default world and make sure the conversion works
- Create a superflat world that consists of ~6 layers of sand (no structures), turn off mobs, and profile it while flying around (https://spark.lucko.me/eZ8SVcHV99 - I can't even find the code on here)
- Test it in the full pack in SP (sand change only)
- Integrate it with GT coils
- Test on MP (in GT5u):
  - Make an EBF and turn it on
  - Relog within its chunk
  - Use MM to change more than 64 blocks at once in its chunk
  - With a small render distance and while the EBF is on, move a few chunks away so that it unloads and move back
  - Do the same, but relog while outside of its range
  - Chunkload the EBF and leave+enter its range

![image](https://github.com/user-attachments/assets/17a07f03-5745-41d1-b3cc-e51d867f7633)
![image](https://github.com/user-attachments/assets/f58d21ce-4b27-4f21-bbc5-829f6532fb3f)
